### PR TITLE
Update unit tests: Metadata loading as parameter (not inside functions)

### DIFF
--- a/kinsim_structure/tests/test_encoding_ExposureFeature.py
+++ b/kinsim_structure/tests/test_encoding_ExposureFeature.py
@@ -151,8 +151,9 @@ def test_get_molecule_exposures(path_pdb, chain_id, radius, n_residues, missing_
     assert missing_residues_calculated['cb'] == missing_exposure['cb']
 
 
-@pytest.mark.parametrize('path_mol2, path_pdb, chain_id, radius, n_residues, missing_exposure', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id, radius, n_residues, missing_exposure', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb',
         'A',
@@ -161,6 +162,7 @@ def test_get_molecule_exposures(path_pdb, chain_id, radius, n_residues, missing_
         {'ca': [5, 6], 'cb': []}
     ),
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/CHK1/3nlb_chainA/pocket.mol2',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/CHK1/3nlb_chainA/protein_pymol.pdb',
         'A',
@@ -169,13 +171,15 @@ def test_get_molecule_exposures(path_pdb, chain_id, radius, n_residues, missing_
         {'ca': [], 'cb': [7]}
     )
 ])
-def test_from_molecule(path_mol2, path_pdb, chain_id, radius, n_residues, missing_exposure):
+def test_from_molecule(path_klifs_metadata, path_mol2, path_pdb, chain_id, radius, n_residues, missing_exposure):
     """
     Test KLIFS ID subset of molecule exposure values and correct selection of HSExposureCB and HSExposureCA values as
     final exposure value (use CB, but if not available use CA).
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2 : pathlib.Path
         Path to mol2 file.
     path_pdb : pathlib.Path
@@ -189,8 +193,6 @@ def test_from_molecule(path_mol2, path_pdb, chain_id, radius, n_residues, missin
     missing_exposure : dict of list of int
         Residue IDs with missing exposures for HSExposureCA and HSExposureCB calculation.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
 
     # Load pdb and mol2 files
     klifs_molecule_loader = KlifsMoleculeLoader()

--- a/kinsim_structure/tests/test_encoding_Fingerprint.py
+++ b/kinsim_structure/tests/test_encoding_Fingerprint.py
@@ -13,27 +13,30 @@ from kinsim_structure.auxiliary import KlifsMoleculeLoader, PdbChainLoader
 PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
-@pytest.mark.parametrize('mol2_filename, pdb_filename, chain_id', [
-    ('HUMAN/ABL1/2g2i_chainA/pocket.mol2', 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb', 'A')
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id', [
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb',
+        'A'
+    )
 ])
-def test_from_molecule(mol2_filename, pdb_filename, chain_id):
+def test_from_molecule(path_klifs_metadata, path_mol2, path_pdb, chain_id):
     """
     Test if Fingerprint class attributes (accessed via property function) have correct DataFrame shape, column and
     index names.
 
     Parameters
     ----------
-    mol2_filename : str
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
+    path_mol2 : pathlib.Path
         Path to mol2 file.
-    pdb_filename : str
+    path_pdb : pathlib.Path
         Path to cif file.
-    chain_id : str
+    chain_id : pathlib.Path
         Chain ID.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / mol2_filename
-    path_pdb = PATH_TEST_DATA / 'KLIFS_download' / pdb_filename
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)

--- a/kinsim_structure/tests/test_encoding_PharmacophoreSizeFeatures.py
+++ b/kinsim_structure/tests/test_encoding_PharmacophoreSizeFeatures.py
@@ -64,27 +64,35 @@ def test_from_residue(residue_name, feature_name, feature):
     assert feature_calculated == feature
 
 
-@pytest.mark.parametrize('mol2_filename, molecule_code, shape', [
-    ('HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2', 'HUMAN/AAK1_4wsq_altA_chainB', (85, 6)),
-    ('HUMAN/ABL1/2g2i_chainA/pocket.mol2', 'HUMAN/ABL1_2g2i_chainA', (82, 6))  # Contains not full KLIFS positions
-
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, molecule_code, shape', [
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
+        'HUMAN/AAK1_4wsq_altA_chainB',
+        (85, 6)
+    ),
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
+        'HUMAN/ABL1_2g2i_chainA',
+        (82, 6)
+    )  # Contains not full KLIFS positions
 ])
-def test_pharmacophoresizefeatures_from_residue(mol2_filename, molecule_code, shape):
+def test_pharmacophoresizefeatures_from_residue(path_klifs_metadata, path_mol2, molecule_code, shape):
     """
-    Test PharmacohpreSizeFeatures class attributes.
+    Test PharmacophoreSizeFeatures class attributes.
 
     Parameters
     ----------
-    mol2_filename : str
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
+    path_mol2 : str
         Path to file originating from test data folder.
     molecule_code : str
         Molecule code as defined by KLIFS in mol2 file.
     """
 
     # Load molecule
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / mol2_filename
-
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
 

--- a/kinsim_structure/tests/test_encoding_PhysicoChemicalFeatures.py
+++ b/kinsim_structure/tests/test_encoding_PhysicoChemicalFeatures.py
@@ -11,27 +11,30 @@ from kinsim_structure.encoding import PhysicoChemicalFeatures
 PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
-@pytest.mark.parametrize('mol2_filename, pdb_filename, chain_id', [
-    ('HUMAN/ABL1/2g2i_chainA/pocket.mol2', 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb', 'A')
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id', [
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2', 
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb', 
+        'A'
+    )
 ])
-def test_from_molecule(mol2_filename, pdb_filename, chain_id):
+def test_from_molecule(path_klifs_metadata, path_mol2, path_pdb, chain_id):
     """
     Test length (85 rows for 85 KLIFS residues) and columns names of features DataFrame.
     Values are tested already in respective feature unit test.
 
     Parameters
     ----------
-    mol2_filename : str
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
+    path_mol2 : pathlib.Path
         Path to mol2 file.
-    pdb_filename : str
+    path_pdb : pathlib.Path
         Path to cif file.
     chain_id : str
         Chain ID.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / mol2_filename
-    path_pdb = PATH_TEST_DATA / 'KLIFS_download' / pdb_filename
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)

--- a/kinsim_structure/tests/test_encoding_SideChainOrientationFeature.py
+++ b/kinsim_structure/tests/test_encoding_SideChainOrientationFeature.py
@@ -15,8 +15,9 @@ from kinsim_structure.encoding import SideChainOrientationFeature
 PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
-@pytest.mark.parametrize('path_mol2, path_pdb, chain_id, res_id_mean, n_pocket_atoms', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id, res_id_mean, n_pocket_atoms', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb',
         'A',
@@ -24,12 +25,14 @@ PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
         659
     )
 ])
-def test_get_pocket_residues(path_mol2, path_pdb, chain_id, res_id_mean, n_pocket_atoms):
+def test_get_pocket_residues(path_klifs_metadata, path_mol2, path_pdb, chain_id, res_id_mean, n_pocket_atoms):
     """
     Test the mean of the pocket's PDB residue IDs and the number of pocket atoms.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2 : pathlib.Path
         Path to mol2 file.
     path_pdb : pathlib.Path
@@ -41,8 +44,6 @@ def test_get_pocket_residues(path_mol2, path_pdb, chain_id, res_id_mean, n_pocke
     n_pocket_atoms : int
         Number of pocket atoms.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
@@ -357,20 +358,23 @@ def test_get_side_chain_centroid(path_pdb, chain_id, residue_id, side_chain_cent
         assert side_chain_centroid_calculated == side_chain_centroid
 
 
-@pytest.mark.parametrize('path_mol2, path_pdb, chain_id, pocket_centroid', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id, pocket_centroid', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb',
         'A',
         np.array([0.99, 21.06, 36.70])
     )
 ])
-def test_get_pocket_centroid(path_mol2, path_pdb, chain_id, pocket_centroid):
+def test_get_pocket_centroid(path_klifs_metadata, path_mol2, path_pdb, chain_id, pocket_centroid):
     """
     Test pocket centroid calculation.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2 : pathlib.Path
         Path to mol2 file.
     path_pdb : pathlib.Path
@@ -380,8 +384,6 @@ def test_get_pocket_centroid(path_mol2, path_pdb, chain_id, pocket_centroid):
     pocket_centroid : list of float
         Pocket centroid coordinates.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
@@ -399,21 +401,24 @@ def test_get_pocket_centroid(path_mol2, path_pdb, chain_id, pocket_centroid):
         assert pocket_centroid_calculated == pocket_centroid
 
 
-@pytest.mark.parametrize('path_mol2, path_pdb, chain_id, n_vectors', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id, n_vectors', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb',
         'A',
         82
     )
 ])
-def test_get_pocket_vectors(path_mol2, path_pdb, chain_id, n_vectors):
+def test_get_pocket_vectors(path_klifs_metadata, path_mol2, path_pdb, chain_id, n_vectors):
     """
     Test if returned DataFrame for pocket vectors contains correct column names and correct number of vectors
     (= number of pocket residues).
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2 : pathlib.Path
         Path to mol2 file.
     path_pdb : pathlib.Path
@@ -423,8 +428,6 @@ def test_get_pocket_vectors(path_mol2, path_pdb, chain_id, n_vectors):
     n_vectors : int
         Number of vectors (= number of pocket residues)
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
@@ -441,21 +444,24 @@ def test_get_pocket_vectors(path_mol2, path_pdb, chain_id, n_vectors):
     assert len(pocket_vectors) == n_vectors
 
 
-@pytest.mark.parametrize('path_mol2, path_pdb, chain_id, angles_mean', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id, angles_mean', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2', 
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb', 
         'A', 
         95.07
     )
 ])
-def test_get_vertex_angles(path_mol2, path_pdb, chain_id, angles_mean):
+def test_get_vertex_angles(path_klifs_metadata, path_mol2, path_pdb, chain_id, angles_mean):
     """
     Test if vertex angles are calculated correctly (check mean angle), and if returned DataFrame contains correct column
     name.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2 : pathlib.Path
         Path to mol2 file.
     path_pdb : pathlib.Path
@@ -465,8 +471,6 @@ def test_get_vertex_angles(path_mol2, path_pdb, chain_id, angles_mean):
     angles_mean : float
         Mean of non-None angles.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
@@ -561,20 +565,23 @@ def test_get_category_from_vertex_angle(vertex_angle, category):
         assert np.isnan(category_calculated)
 
 
-@pytest.mark.parametrize('path_mol2, path_pdb, chain_id', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, path_pdb, chain_id', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2', 
         PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/protein_pymol.pdb', 
         'A'
     )
 ])
-def test_from_molecule(path_mol2, path_pdb, chain_id):
+def test_from_molecule(path_klifs_metadata, path_mol2, path_pdb, chain_id):
     """
     Test if SideChainOrientation attributes features and features_verbose contain the correct column names.
     Values are tested already in other test_sidechainorientation_* unit tests.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2 : pathlib.Path
         Path to mol2 file.
     path_pdb : pathlib.Path
@@ -582,8 +589,6 @@ def test_from_molecule(path_mol2, path_pdb, chain_id):
     chain_id : str
         Chain ID.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)

--- a/kinsim_structure/tests/test_encoding_SpatialFeatures.py
+++ b/kinsim_structure/tests/test_encoding_SpatialFeatures.py
@@ -13,22 +13,24 @@ from kinsim_structure.encoding import SpatialFeatures
 PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
-@pytest.mark.parametrize('mol2_filename', [
-    'HUMAN/ABL1/2g2i_chainA/pocket.mol2'
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2', [
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2'
+    )
 ])
-def test_from_molecule(mol2_filename):
+def test_from_molecule(path_klifs_metadata, path_mol2):
     """
     Test length (85 rows for 85 KLIFS residues) and columns names of features DataFrame.
     Values are tested already in respective feature unit test.
 
     Parameters
     ----------
-    mol2_filename : str
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
+    path_mol2 : pathlib.Path
         Path to mol2 file.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / mol2_filename
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
@@ -47,18 +49,38 @@ def test_from_molecule(mol2_filename):
     assert len(features) == 85
 
 
-@pytest.mark.parametrize('mol2_filename, reference_point_name, anchor_residue_klifs_ids, x_coordinate', [
-    ('HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2', 'hinge_region', [16, 47, 80], 6.25545),
-    ('HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2', 'dfg_region', [20, 23, 81], 11.6846),
-    ('HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2', 'front_pocket', [6, 48, 75], float('nan'))
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, reference_point_name, anchor_residue_klifs_ids, x_coordinate', [
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
+        'hinge_region',
+        [16, 47, 80],
+        6.25545
+    ),
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
+        'dfg_region',
+        [20, 23, 81],
+        11.6846
+    ),
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
+        'front_pocket',
+        [6, 48, 75],
+        float('nan')
+    )
 ])
-def test_get_anchor_atoms(mol2_filename, reference_point_name, anchor_residue_klifs_ids, x_coordinate):
+def test_get_anchor_atoms(path_klifs_metadata, path_mol2, reference_point_name, anchor_residue_klifs_ids, x_coordinate):
     """
     Test function that calculates the anchor atoms for different scenarios (missing anchor residues, missing neighbors)
 
     Parameters
     ----------
-    mol2_filename : str
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
+    path_mol2 : pathlib.Path
         Path to file originating from test data folder.
     reference_point_name : str
         Reference point name, e.g. 'hinge_region'.
@@ -67,9 +89,6 @@ def test_get_anchor_atoms(mol2_filename, reference_point_name, anchor_residue_kl
     x_coordinate: float
         X coordinate of first anchor atom.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / mol2_filename
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
@@ -105,23 +124,26 @@ def test_get_anchor_atoms(mol2_filename, reference_point_name, anchor_residue_kl
         assert anchors[reference_point_name].loc[anchor_residue_klifs_ids[0], 'x'] == x_coordinate
 
 
-@pytest.mark.parametrize('mol2_filename, x_coordinate', [
-    ('HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2', 1.02664)
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2, x_coordinate', [
+    (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
+        1.02664
+    )
 ])
-def test_get_reference_points(mol2_filename, x_coordinate):
+def test_get_reference_points(path_klifs_metadata, path_mol2, x_coordinate):
     """
     Test calculation of reference point "centroid" of a pocket.
 
     Parameters
     ----------
-    mol2_filename : str
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
+    path_mol2 : pathlib.Path
         Path to file originating from test data folder.
     x_coordinate: float
         X coordinate of the centroid.
     """
-
-    path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / mol2_filename
 
     klifs_molecule_loader = KlifsMoleculeLoader()
     klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)

--- a/kinsim_structure/tests/test_preprocessing_Mol2ToPdbConverter.py
+++ b/kinsim_structure/tests/test_preprocessing_Mol2ToPdbConverter.py
@@ -13,7 +13,7 @@ PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
 @pytest.mark.parametrize('path_mol2', [
-    'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2'
+    PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2'
 ])
 def test_set_path_mol2(path_mol2):
     """
@@ -21,11 +21,9 @@ def test_set_path_mol2(path_mol2):
 
     Parameters
     ----------
-    path_mol2 : str
+    path_mol2 : pathlib.Path
         Path to mol2 file.
     """
-
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / path_mol2
 
     converter = Mol2ToPdbConverter()
 
@@ -33,7 +31,7 @@ def test_set_path_mol2(path_mol2):
 
 
 @pytest.mark.parametrize('path_mol2', [
-    'xxx.mol2'
+    PATH_TEST_DATA / 'KLIFS_download' / 'xxx.mol2'
 ])
 def test_set_path_mol2_filenotfounderror(path_mol2):
     """
@@ -41,11 +39,9 @@ def test_set_path_mol2_filenotfounderror(path_mol2):
 
     Parameters
     ----------
-    path_mol2 : str
+    path_mol2 : pathlib.Path
         Path to mol2 file.
     """
-
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / path_mol2
 
     with pytest.raises(FileNotFoundError):
         converter = Mol2ToPdbConverter()
@@ -53,7 +49,7 @@ def test_set_path_mol2_filenotfounderror(path_mol2):
 
 
 @pytest.mark.parametrize('path_mol2', [
-    'HUMAN/ADCK3/5i35_chainA/protein_correct.pdb'  # Existing file but no mol2
+    PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_correct.pdb'  # Existing file but no mol2
 ])
 def test_set_path_mol2_valueerror(path_mol2):
     """
@@ -61,11 +57,9 @@ def test_set_path_mol2_valueerror(path_mol2):
 
     Parameters
     ----------
-    path_mol2 : str
+    path_mol2 : pathlib.Path
         Path to mol2 file.
     """
-
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / path_mol2
 
     with pytest.raises(ValueError):
         converter = Mol2ToPdbConverter()
@@ -74,14 +68,14 @@ def test_set_path_mol2_valueerror(path_mol2):
 
 @pytest.mark.parametrize('path_mol2_input, path_pdb_input, path_pdb_output', [
     (
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
         None,  # Do not define pdb path - will be set automatically
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.pdb'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.pdb'
     ),
     (
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket2.pdb',  # Define some pdb path
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket2.pdb'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket2.pdb',  # Define some pdb path
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket2.pdb'
     )
 ])
 def test_set_path_pdb(path_mol2_input, path_pdb_input, path_pdb_output):
@@ -90,19 +84,13 @@ def test_set_path_pdb(path_mol2_input, path_pdb_input, path_pdb_output):
 
     Parameters
     ----------
-    path_mol2_input : str
+    path_mol2_input : pathlib.Path
         Path to mol2 file.
-    path_pdb_input : str or None
+    path_pdb_input : pathlib.Path or None
         Path to pdb file (None: Automatically set pdb path in same folder as mol2 file)
     path_pdb_output : pathlib.Path
         Path to pdb file which is returned from function.
     """
-
-    path_mol2_input = PATH_TEST_DATA / 'KLIFS_download' / path_mol2_input
-    path_pdb_output = PATH_TEST_DATA / 'KLIFS_download' / path_pdb_output
-
-    if path_pdb_input is not None:
-        path_pdb_input = PATH_TEST_DATA / 'KLIFS_download' / path_pdb_input
 
     converter = Mol2ToPdbConverter()
     converter.path_mol2 = path_mol2_input
@@ -114,8 +102,8 @@ def test_set_path_pdb(path_mol2_input, path_pdb_input, path_pdb_output):
 
 @pytest.mark.parametrize('path_mol2_input, path_pdb_input', [
     (
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
-        'xxx/pocket.pdb'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'xxx/pocket.pdb'
     )
 ])
 def test_set_path_pdb_filenotfounderror(path_mol2_input, path_pdb_input):
@@ -125,17 +113,11 @@ def test_set_path_pdb_filenotfounderror(path_mol2_input, path_pdb_input):
 
     Parameters
     ----------
-    path_mol2_input : str
+    path_mol2_input : pathlib.Path
         Path to mol2 file.
-    path_pdb_input : str or None
+    path_pdb_input : pathlib.Path or None
         Path to pdb file (None: Automatically set pdb path in same folder as mol2 file)
     """
-
-    if path_mol2_input is not None:
-        path_mol2_input = PATH_TEST_DATA / 'KLIFS_download' / path_mol2_input
-
-    if path_pdb_input is not None:
-        path_pdb_input = PATH_TEST_DATA / 'KLIFS_download' / path_pdb_input
 
     with pytest.raises(FileNotFoundError):
 
@@ -148,19 +130,19 @@ def test_set_path_pdb_filenotfounderror(path_mol2_input, path_pdb_input):
 @pytest.mark.parametrize('path_mol2_input, path_pdb_input', [
     (
         None,
-        'KLIFS_download/HUMAN/AAK1/4wsq_altA_chainA/pocket.pdb'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.pdb'
     ),
     (
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2'
     ),
     (
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket'
     ),
     (
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket/'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket/'
     )
 ])
 def test_set_path_pdb_valueerror(path_mol2_input, path_pdb_input):
@@ -170,17 +152,11 @@ def test_set_path_pdb_valueerror(path_mol2_input, path_pdb_input):
 
     Parameters
     ----------
-    path_mol2_input : str
+    path_mol2_input : pathlib.Path
         Path to mol2 file.
-    path_pdb_input : str or None
+    path_pdb_input : pathlib.Path or None
         Path to pdb file (None: Automatically set pdb path in same folder as mol2 file)
     """
-
-    if path_mol2_input is not None:
-        path_mol2_input = PATH_TEST_DATA / 'KLIFS_download' / path_mol2_input
-
-    if path_pdb_input is not None:
-        path_pdb_input = PATH_TEST_DATA / 'KLIFS_download' / path_pdb_input
 
     with pytest.raises(ValueError):
 
@@ -192,8 +168,8 @@ def test_set_path_pdb_valueerror(path_mol2_input, path_pdb_input):
 
 @pytest.mark.parametrize('path_mol2, path_pdb', [
     (
-        'KLIFS_download/HUMAN/ADCK3/5i35_chainA/protein.mol2',
-        'KLIFS_download/HUMAN/ADCK3/5i35_chainA/protein_correct.pdb'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_correct.pdb'
     )
 ])
 def test_report_inconsistent_conversion(path_mol2, path_pdb):
@@ -202,15 +178,12 @@ def test_report_inconsistent_conversion(path_mol2, path_pdb):
 
     Parameters
     ----------
-    path_mol2 : pathlib.Path or str
+    path_mol2 : pathlib.Path
         Path to mol2 file.
-    path_pdb : None or pathlib.Path or str
+    path_pdb : pathlib.Path or None
         Path to pdb file (= converted mol2 file). Directory must exist.
         Default is None - saves pdb file next to the mol2 file in same directory with the same filename.
     """
-
-    path_mol2 = PATH_TEST_DATA / path_mol2
-    path_pdb = PATH_TEST_DATA / path_pdb
 
     converter = Mol2ToPdbConverter()
 
@@ -219,8 +192,8 @@ def test_report_inconsistent_conversion(path_mol2, path_pdb):
 
 @pytest.mark.parametrize('path_mol2, path_pdb, inconsistency', [
     (
-        'HUMAN/ADCK3/5i35_chainA/protein.mol2',
-        'HUMAN/ADCK3/5i35_chainA/protein_irregular_n_atoms.pdb',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_irregular_n_atoms.pdb',
         pd.DataFrame(
             [
                 ['HUMAN/ADCK3/5i35_chainA', 'Unequal number of atoms', {'mol2': 6194, 'pdb': 6193}]
@@ -229,8 +202,8 @@ def test_report_inconsistent_conversion(path_mol2, path_pdb):
         )
     ),
     (
-        'HUMAN/ADCK3/5i35_chainA/protein.mol2',
-        'HUMAN/ADCK3/5i35_chainA/protein_irregular_x_mean.pdb',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_irregular_x_mean.pdb',
         pd.DataFrame(
             [
                 ['HUMAN/ADCK3/5i35_chainA', 'Unequal x coordinate mean', -0.14]
@@ -239,8 +212,8 @@ def test_report_inconsistent_conversion(path_mol2, path_pdb):
         )
     ),
     (
-        'HUMAN/ADCK3/5i35_chainA/protein.mol2',
-        'HUMAN/ADCK3/5i35_chainA/protein_irregular_y_mean.pdb',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_irregular_y_mean.pdb',
         pd.DataFrame(
             [
                 ['HUMAN/ADCK3/5i35_chainA', 'Unequal y coordinate mean', -0.15]
@@ -249,8 +222,8 @@ def test_report_inconsistent_conversion(path_mol2, path_pdb):
         )
     ),
     (
-        'HUMAN/ADCK3/5i35_chainA/protein.mol2',
-        'HUMAN/ADCK3/5i35_chainA/protein_irregular_z_mean.pdb',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_irregular_z_mean.pdb',
         pd.DataFrame(
             [
                 ['HUMAN/ADCK3/5i35_chainA', 'Unequal z coordinate mean', -0.14]
@@ -259,8 +232,8 @@ def test_report_inconsistent_conversion(path_mol2, path_pdb):
         )
     ),
     (
-        'HUMAN/ADCK3/5i35_chainA/protein.mol2',
-        'HUMAN/ADCK3/5i35_chainA/protein_irregular_record_name.pdb',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_irregular_record_name.pdb',
         pd.DataFrame(
             [
                 ['HUMAN/ADCK3/5i35_chainA', 'Non-ATOM entries', {'record_name': {'HETATM'}, 'residue_name': {'GLU'}}]
@@ -269,8 +242,8 @@ def test_report_inconsistent_conversion(path_mol2, path_pdb):
         )
     ),
     (
-        'HUMAN/ADCK3/5i35_chainA/protein.mol2',
-        'HUMAN/ADCK3/5i35_chainA/protein_irregular_residue_details.pdb',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_irregular_residue_details.pdb',
         pd.DataFrame(
             [
                 ['HUMAN/ADCK3/5i35_chainA', 'Unequal residue ID/name', {'mol2': {'GLU261'}, 'pdb': {'GLU999'}}]
@@ -285,15 +258,12 @@ def test_report_inconsistent_conversion_valueerror(path_mol2, path_pdb, inconsis
 
     Parameters
     ----------
-    path_mol2 : pathlib.Path or str
+    path_mol2 : pathlib.Path
         Path to mol2 file.
-    path_pdb : None or pathlib.Path or str
+    path_pdb : pathlib.Path or None
         Path to pdb file (= converted mol2 file). Directory must exist.
         Default is None - saves pdb file next to the mol2 file in same directory with the same filename.
     """
-
-    path_mol2 = PATH_TEST_DATA / 'KLIFS_download' / path_mol2
-    path_pdb = PATH_TEST_DATA / 'KLIFS_download' / path_pdb
 
     converter = Mol2ToPdbConverter()
     converter._report_inconsistent_conversion(path_mol2, path_pdb)
@@ -303,9 +273,9 @@ def test_report_inconsistent_conversion_valueerror(path_mol2, path_pdb, inconsis
 
 @pytest.mark.parametrize('path_mol2_input, path_pdb_input, path_pdb_output', [
     (
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.mol2',
         None,
-        'HUMAN/AAK1/4wsq_altA_chainA/pocket.pdb'
+        PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainA/pocket.pdb'
     )
 ])
 def test_from_file(path_mol2_input, path_pdb_input, path_pdb_output):
@@ -314,19 +284,13 @@ def test_from_file(path_mol2_input, path_pdb_input, path_pdb_output):
 
     Parameters
     ----------
-    path_mol2_input : str
+    path_mol2_input : pathlib.Path
         Path to input mol2 file.
-    path_pdb_input : str
+    path_pdb_input : pathlib.Path
         Path to input pdb file.
-    path_pdb_output : str
+    path_pdb_output : pathlib.Path
         Path to output pdb file.
     """
-
-    path_mol2_input = PATH_TEST_DATA / 'KLIFS_download' / path_mol2_input
-    path_pdb_output = PATH_TEST_DATA / 'KLIFS_download' / path_pdb_output
-
-    if path_pdb_input is not None:
-        path_pdb_input = PATH_TEST_DATA / 'KLIFS_download' / path_pdb_input
 
     converter = Mol2ToPdbConverter()
     converter.from_file(path_mol2_input, path_pdb_input)
@@ -345,7 +309,7 @@ def test_from_file(path_mol2_input, path_pdb_input, path_pdb_output):
     (
             pd.DataFrame(['HUMAN/ADCK3/5i35_chainA'], columns=['filepath']),
             PATH_TEST_DATA / 'KLIFS_download',
-            'HUMAN/ADCK3/5i35_chainA/protein_pymol.pdb'
+            PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ADCK3/5i35_chainA/protein_pymol.pdb'
     )
 ])
 def ttest_from_klifs_metadata(klifs_metadata, path_klifs_download, path_pdb):  # TODO PyMol cannot be launched mulitple times...
@@ -356,13 +320,11 @@ def ttest_from_klifs_metadata(klifs_metadata, path_klifs_download, path_pdb):  #
     ----------
     klifs_metadata : pandas.DataFrame
         KLIFS metadata describing the KLIFS dataset.
-    path_klifs_download : pathlib.Path or str
+    path_klifs_download : pathlib.Path
         Path to directory of KLIFS dataset files.
-    path_pdb : str
+    path_pdb : pathlib.Path
         Pdb path to converted pdb file.
     """
-
-    path_pdb = PATH_TEST_DATA / 'KLIFS_download' / path_pdb
 
     converter = Mol2ToPdbConverter()
     converter.from_klifs_metadata(klifs_metadata, path_klifs_download)

--- a/kinsim_structure/tests/test_similarity_FeatureDistances.py
+++ b/kinsim_structure/tests/test_similarity_FeatureDistances.py
@@ -15,12 +15,14 @@ from kinsim_structure.similarity import FeatureDistances
 PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
-def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
+def generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids):
     """
     Helper function: Generate multiple fingerprints from files.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     paths_mol2 : list of pathlib.Path
         Paths to multiple mol2 files.
     paths_pdb : list of pathlib.Path
@@ -38,8 +40,6 @@ def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
 
     for path_mol2, path_pdb, chain_id in zip(paths_mol2, paths_pdb, chain_ids):
 
-        path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-
         klifs_molecule_loader = KlifsMoleculeLoader()
         klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
         pdb_chain_loader = PdbChainLoader()
@@ -53,8 +53,9 @@ def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
     return fingerprints
 
 
-@pytest.mark.parametrize('paths_mol2, paths_pdb, chain_ids, feature_type_dimension', [
+@pytest.mark.parametrize('path_klifs_metadata, paths_mol2, paths_pdb, chain_ids, feature_type_dimension', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         [
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2'
@@ -70,12 +71,14 @@ def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
         pd.Series([8, 4, 3], index='physicochemical distances moments'.split())
     )
 ])
-def test_from_fingerprints(paths_mol2, paths_pdb, chain_ids, feature_type_dimension):
+def test_from_fingerprints(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids, feature_type_dimension):
     """
     Test data type and dimensions of feature distances between two fingerprints.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     paths_mol2 : list of str
         Paths to two mol2 files.
     paths_pdb : list of str
@@ -85,7 +88,7 @@ def test_from_fingerprints(paths_mol2, paths_pdb, chain_ids, feature_type_dimens
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids)
 
     # Get feature distances and check if format is correct
     feature_distances = FeatureDistances()
@@ -220,8 +223,9 @@ def test_calculate_feature_distance_valueerror(feature_pair, distance_measure):
         feature_distance_generator._calculate_feature_distance(feature_pair, distance_measure)
 
 
-@pytest.mark.parametrize('paths_mol2, paths_pdb, chain_ids, n_bits_wo_nan_size', [
+@pytest.mark.parametrize('path_klifs_metadata, paths_mol2, paths_pdb, chain_ids, n_bits_wo_nan_size', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         [
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2'
@@ -237,12 +241,14 @@ def test_calculate_feature_distance_valueerror(feature_pair, distance_measure):
         82
     )
 ])
-def test_extract_fingerprint_pair(paths_mol2, paths_pdb, chain_ids, n_bits_wo_nan_size):
+def test_extract_fingerprint_pair(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids, n_bits_wo_nan_size):
     """
     Test extracting fingerprint pairs for each feature.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     paths_mol2 : list of str
         Paths to two mol2 files.
     paths_pdb : list of str
@@ -254,7 +260,7 @@ def test_extract_fingerprint_pair(paths_mol2, paths_pdb, chain_ids, n_bits_wo_na
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids)
 
     # Fingerprint pair
     feature_distances_generator = FeatureDistances()

--- a/kinsim_structure/tests/test_similarity_FeatureDistancesGenerator.py
+++ b/kinsim_structure/tests/test_similarity_FeatureDistancesGenerator.py
@@ -13,12 +13,14 @@ from kinsim_structure.similarity import FeatureDistances, FeatureDistancesGenera
 PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
-def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
+def generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids):
     """
     Helper function: Generate multiple fingerprints from files.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     paths_mol2 : list of pathlib.Path
         Paths to multiple mol2 files.
     paths_pdb : list of pathlib.Path
@@ -35,8 +37,6 @@ def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
     fingerprints = []
 
     for path_mol2, path_pdb, chain_id in zip(paths_mol2, paths_pdb, chain_ids):
-
-        path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
 
         klifs_molecule_loader = KlifsMoleculeLoader()
         klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
@@ -104,8 +104,9 @@ def test_get_fingerprint_pairs(fingerprints, pairs):
         assert pair_calculated == pair
 
 
-@pytest.mark.parametrize('paths_mol2, paths_pdb, chain_ids', [
+@pytest.mark.parametrize('path_klifs_metadata, paths_mol2, paths_pdb, chain_ids', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         [
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2', 
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2'
@@ -121,12 +122,14 @@ def test_get_fingerprint_pairs(fingerprints, pairs):
     )
 
 ])
-def test_get_feature_distances(paths_mol2, paths_pdb, chain_ids):
+def test_get_feature_distances(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids):
     """
     Test if return type is instance of FeatureDistance class.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     paths_mol2 : list of str
         Paths to two mol2 files.
     paths_pdb : list of str
@@ -136,7 +139,7 @@ def test_get_feature_distances(paths_mol2, paths_pdb, chain_ids):
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids)
 
     # Fingerprint dictionary and pair names
     pair = [i.molecule_code for i in fingerprints]
@@ -149,8 +152,9 @@ def test_get_feature_distances(paths_mol2, paths_pdb, chain_ids):
     assert isinstance(feature_distances_calculated, FeatureDistances)
 
 
-@pytest.mark.parametrize('paths_mol2, paths_pdb, chain_ids', [
+@pytest.mark.parametrize('path_klifs_metadata, paths_mol2, paths_pdb, chain_ids', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         [
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
@@ -169,12 +173,14 @@ def test_get_feature_distances(paths_mol2, paths_pdb, chain_ids):
     )
 
 ])
-def test_get_feature_distances_from_list(paths_mol2, paths_pdb, chain_ids):
+def test_get_feature_distances_from_list(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids):
     """
     Test if return type is instance of list of FeatureDistance class.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     paths_mol2 : list of str
         Paths to multiple mol2 files.
     paths_pdb : list of str
@@ -184,7 +190,7 @@ def test_get_feature_distances_from_list(paths_mol2, paths_pdb, chain_ids):
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids)
 
     # Fingerprint dictionary and pair names
     fingerprints = {i.molecule_code: i for i in fingerprints}
@@ -204,8 +210,9 @@ def test_get_feature_distances_from_list(paths_mol2, paths_pdb, chain_ids):
 
 
 @pytest.mark.parametrize(
-    'paths_mol2, paths_pdb, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names', [
+    'path_klifs_metadata, paths_mol2, paths_pdb, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names', [
         (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
             [
                 PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
                 PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
@@ -229,13 +236,15 @@ def test_get_feature_distances_from_list(paths_mol2, paths_pdb, chain_ids):
     ]
 )
 def test_from_fingerprints(
-        paths_mol2, paths_pdb, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names
+        path_klifs_metadata, paths_mol2, paths_pdb, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names
 ):
     """
     Test FeatureDistancesGenerator class attributes.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     paths_mol2 : list of str
         Paths to multiple mol2 files.
     paths_pdb : list of str
@@ -247,7 +256,7 @@ def test_from_fingerprints(
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids)
 
     # Fingerprint dictionary and pair names
     fingerprint_generator = FingerprintGenerator()

--- a/kinsim_structure/tests/test_similarity_FingerprintDistanceGenerator.py
+++ b/kinsim_structure/tests/test_similarity_FingerprintDistanceGenerator.py
@@ -16,15 +16,17 @@ from kinsim_structure.similarity import FeatureDistances, FingerprintDistance, \
 PATH_TEST_DATA = Path(__name__).parent / 'kinsim_structure' / 'tests' / 'data'
 
 
-def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
+def generate_fingerprints_from_files(path_klifs_metadata, paths_mol2, paths_pdb, chain_ids):
     """
     Helper function: Generate multiple fingerprints from files.
 
     Parameters
     ----------
-    paths_mol2 : list of str
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
+    paths_mol2 : list of pathlib.Path
         Paths to multiple mol2 files.
-    paths_pdb : list of str
+    paths_pdb : list of pathlib.Path
         Paths to multiple cif files.
     chain_ids : list of str
         Multiple chain IDs.
@@ -39,8 +41,6 @@ def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
 
     for path_mol2, path_pdb, chain_id in zip(paths_mol2, paths_pdb, chain_ids):
 
-        path_klifs_metadata = PATH_TEST_DATA / 'klifs_metadata.csv'
-
         klifs_molecule_loader = KlifsMoleculeLoader()
         klifs_molecule_loader.from_file(path_mol2, path_klifs_metadata)
         pdb_chain_loader = PdbChainLoader()
@@ -54,8 +54,9 @@ def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
     return fingerprints
 
 
-@pytest.mark.parametrize('path_mol2s, path_pdbs, chain_ids', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2s, path_pdbs, chain_ids', [
     (
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         [
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2'
@@ -71,12 +72,14 @@ def generate_fingerprints_from_files(paths_mol2, paths_pdb, chain_ids):
     )
 
 ])
-def test_get_fingerprint_distance(path_mol2s, path_pdbs, chain_ids):
+def test_get_fingerprint_distance(path_klifs_metadata, path_mol2s, path_pdbs, chain_ids):
     """
     Test if return type is FingerprintDistance class instance.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2s : list of str
         Paths to two mol2 files.
     path_pdbs : list of str
@@ -86,7 +89,7 @@ def test_get_fingerprint_distance(path_mol2s, path_pdbs, chain_ids):
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(path_mol2s, path_pdbs, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, path_mol2s, path_pdbs, chain_ids)
 
     # FeatureDistances
     feature_distances = FeatureDistances()
@@ -101,8 +104,10 @@ def test_get_fingerprint_distance(path_mol2s, path_pdbs, chain_ids):
     assert isinstance(fingerprint_distance_calculated, FingerprintDistance)
 
 
-@pytest.mark.parametrize('path_mol2s, path_pdbs, chain_ids', [
+@pytest.mark.parametrize('path_klifs_metadata, path_mol2s, path_pdbs, chain_ids', [
     (
+
+        PATH_TEST_DATA / 'klifs_metadata.csv',
         [
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
             PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
@@ -121,12 +126,14 @@ def test_get_fingerprint_distance(path_mol2s, path_pdbs, chain_ids):
     )
 
 ])
-def test_get_fingerprint_distance_from_list(path_mol2s, path_pdbs, chain_ids):
+def test_get_fingerprint_distance_from_list(path_klifs_metadata, path_mol2s, path_pdbs, chain_ids):
     """
     Test if return type is instance of list of FeatureDistance class instances.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2s : list of str
         Paths to multiple mol2 files.
     path_pdbs : list of str
@@ -136,7 +143,7 @@ def test_get_fingerprint_distance_from_list(path_mol2s, path_pdbs, chain_ids):
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(path_mol2s, path_pdbs, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, path_mol2s, path_pdbs, chain_ids)
 
     # FingerprintGenerator
     fingerprint_generator = FingerprintGenerator()
@@ -160,8 +167,9 @@ def test_get_fingerprint_distance_from_list(path_mol2s, path_pdbs, chain_ids):
 
 
 @pytest.mark.parametrize(
-    'path_mol2s, path_pdbs, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names', [
+    'path_klifs_metadata, path_mol2s, path_pdbs, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names', [
         (
+            PATH_TEST_DATA / 'klifs_metadata.csv',
             [
                 PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/ABL1/2g2i_chainA/pocket.mol2',
                 PATH_TEST_DATA / 'KLIFS_download' / 'HUMAN/AAK1/4wsq_altA_chainB/pocket.mol2',
@@ -185,13 +193,15 @@ def test_get_fingerprint_distance_from_list(path_mol2s, path_pdbs, chain_ids):
     ]
 )
 def test_from_feature_distances_generator(
-        path_mol2s, path_pdbs, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names
+        path_klifs_metadata, path_mol2s, path_pdbs, chain_ids, distance_measure, feature_weights, molecule_codes, kinase_names
 ):
     """
     Test FingerprintDistanceGenerator class attributes.
 
     Parameters
     ----------
+    path_klifs_metadata : pathlib.Path
+        Path to unfiltered KLIFS metadata.
     path_mol2s : list of str
         Paths to multiple mol2 files.
     path_pdbs : list of str
@@ -218,7 +228,7 @@ def test_from_feature_distances_generator(
     """
 
     # Fingerprints
-    fingerprints = generate_fingerprints_from_files(path_mol2s, path_pdbs, chain_ids)
+    fingerprints = generate_fingerprints_from_files(path_klifs_metadata, path_mol2s, path_pdbs, chain_ids)
 
     # FingerprintGenerator
     fingerprint_generator = FingerprintGenerator()


### PR DESCRIPTION
## Description
Unit test sometimes need to load metadata. Currently, this is done within the functions. In order to make clear, what kind of data the functions need, pass the path to the metadata as function parameter.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Pass path to metadata as function parameter, update docstrings, and pytest input.

## Status
- [x] Ready to go