### PR TITLE
Remove windows from CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-latest]  # windows-latest
         python-version: [3.7, 3.8, 3.9]
 
     steps:


### PR DESCRIPTION
## Description
CI fails for windows (repeatedly) with a connection error which does not seem to be windows-specific. Maybe KLIFS is overwhelmed by the 3x3 CI matrix (3 OS x 3 Python versions)?

`C:\Miniconda\envs\test\lib\site-packages\requests\adapters.py:498: RequestsFutureAdapterConnectionError`
Check out CI run: https://github.com/volkamerlab/kissim/runs/1778396857

Remove windows from CI for now but opened issue to remind myself to investigate this more in the future: https://github.com/volkamerlab/kissim/issues/35

## Todos
  - [x] Remove windows from CI
  - [x] Check if CI is successful now

## Questions
None

## Status
- [x] Ready to go