### PR TITLE
Reduce memory load

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,6 +17,7 @@ dependencies:
   - jupyter
   - jupyterlab=2
   - ipywidgets>=7.5
+  - ijson
   # Testing
   - pytest 5.*
   - pytest-cov

--- a/kissim/comparison/feature_distances.py
+++ b/kissim/comparison/feature_distances.py
@@ -156,8 +156,10 @@ class FeatureDistances:
         feature_distances = cls()
         feature_distances.structure_pair_ids = tuple(feature_distances_dict["structure_pair_ids"])
         feature_distances.kinase_pair_ids = tuple(feature_distances_dict["kinase_pair_ids"])
-        feature_distances.distances = np.array(feature_distances_dict["distances"])
-        feature_distances.bit_coverages = np.array(feature_distances_dict["bit_coverages"])
+        feature_distances.distances = np.array(feature_distances_dict["distances"], dtype=np.float)
+        feature_distances.bit_coverages = np.array(
+            feature_distances_dict["bit_coverages"], dtype=np.float
+        )
         return feature_distances
 
     def _get_feature_distances_and_bit_coverages(

--- a/kissim/comparison/fingerprint_distance_generator.py
+++ b/kissim/comparison/fingerprint_distance_generator.py
@@ -7,6 +7,7 @@ Defines the pairwise fingerprint distances for a set of fingerprints.
 import datetime
 from itertools import repeat
 import json
+import ijson
 import logging
 from multiprocessing import Pool
 from pathlib import Path
@@ -308,13 +309,13 @@ class FingerprintDistanceGenerator:
             tuple(i) for i in fingerprint_distance_generator.structure_kinase_ids
         ]
         fingerprint_distance_generator.feature_weights = np.array(
-            fingerprint_distance_generator.feature_weights
+            fingerprint_distance_generator.feature_weights, dtype=np.float
         )
         fingerprint_distance_generator._distances = np.array(
-            fingerprint_distance_generator._distances
+            fingerprint_distance_generator._distances, dtype=np.float
         )
         fingerprint_distance_generator._bit_coverages = np.array(
-            fingerprint_distance_generator._bit_coverages
+            fingerprint_distance_generator._bit_coverages, dtype=np.float
         )
 
         return fingerprint_distance_generator

--- a/kissim/comparison/fingerprint_distance_generator.py
+++ b/kissim/comparison/fingerprint_distance_generator.py
@@ -189,7 +189,7 @@ class FingerprintDistanceGenerator:
         fingerprint_distance_list = (
             fingerprint_distance_generator._get_fingerprint_distance_from_list(
                 fingerprint_distance_generator._get_fingerprint_distance,
-                list(feature_distances_generator.data.values()),
+                feature_distances_generator.data,
                 feature_weights,
                 n_cores,
             )

--- a/kissim/comparison/fingerprint_distance_generator.py
+++ b/kissim/comparison/fingerprint_distance_generator.py
@@ -7,7 +7,6 @@ Defines the pairwise fingerprint distances for a set of fingerprints.
 import datetime
 from itertools import repeat
 import json
-import ijson
 import logging
 from multiprocessing import Pool
 from pathlib import Path

--- a/kissim/tests/comparison/test_feature_distances_generator.py
+++ b/kissim/tests/comparison/test_feature_distances_generator.py
@@ -49,12 +49,9 @@ class TestsFeatureDistancesGenerator:
         assert isinstance(feature_distances_generator, FeatureDistancesGenerator)
 
         # Test attributes
-        assert isinstance(feature_distances_generator.data, dict)
+        assert isinstance(feature_distances_generator.data, list)
+        assert isinstance(feature_distances_generator.data[0], FeatureDistances)
         assert isinstance(feature_distances_generator.structure_kinase_ids, list)
-
-        # Test example value from dictionary
-        example_key = list(feature_distances_generator.data.keys())[0]
-        assert isinstance(feature_distances_generator.data[example_key], FeatureDistances)
 
     @pytest.mark.parametrize(
         "structure_klifs_ids, klifs_session, n_cores",
@@ -75,12 +72,9 @@ class TestsFeatureDistancesGenerator:
         assert isinstance(feature_distances_generator, FeatureDistancesGenerator)
 
         # Test attributes
-        assert isinstance(feature_distances_generator.data, dict)
+        assert isinstance(feature_distances_generator.data, list)
+        assert isinstance(feature_distances_generator.data[0], FeatureDistances)
         assert isinstance(feature_distances_generator.structure_kinase_ids, list)
-
-        # Test example value from dictionary
-        example_key = list(feature_distances_generator.data.keys())[0]
-        assert isinstance(feature_distances_generator.data[example_key], FeatureDistances)
 
     def test_to_from_json(self, feature_distances_generator):
 

--- a/kissim/tests/comparison/test_fingerprint_distance_generator.py
+++ b/kissim/tests/comparison/test_fingerprint_distance_generator.py
@@ -124,7 +124,7 @@ class TestsFingerprintDistanceGenerator:
         fingerprint_distance_list = (
             fingerprint_distance_generator._get_fingerprint_distance_from_list(
                 fingerprint_distance_generator._get_fingerprint_distance,
-                list(feature_distances_generator.data.values()),
+                feature_distances_generator.data,
                 None,
                 1,
             )

--- a/kissim/tests/conftest.py
+++ b/kissim/tests/conftest.py
@@ -101,11 +101,7 @@ def feature_distances_generator():
     feature_distances3.bit_coverages = np.array([0.0] * 15)
 
     # FeatureDistancesGenerator
-    data = {
-        feature_distances1.structure_pair_ids: feature_distances1,
-        feature_distances2.structure_pair_ids: feature_distances2,
-        feature_distances3.structure_pair_ids: feature_distances3,
-    }
+    data = [feature_distances1, feature_distances2, feature_distances3]
 
     # FeatureDistancesGenerator
     feature_distances_generator = FeatureDistancesGenerator()


### PR DESCRIPTION
## Description
Loading `FeatureDistancesGenerator` from JSON file takes up too much memory (6GB JSON file takes up over 30GB of RAM). This happens because the full JSON string is loaded into memory, then converted to a dict and then used to set up the `FeatureDistancesGenerator` object. Not so great.

Use `ijson` instead: The JSON content is loaded as generator - so we can load only one data point at a time into memory.

Even better - in the future - use a database, see #46.

## Todos

  - [x] Convert `FeatureDistancesGenerator.data` from dict to list (dict values); the dict keys are part of the dict values
  - [x] Add `ijson` to environment
  - [x] Save "NaN" values in JSON format as "null" (needed for `ijson`)
  - [x] Load JSON data iteratively into the `FeatureDistancesGenerator` using `ijson`

## Questions
None.

## Status
- [ ] Ready to go