### PR TITLE
FIX: Sort kinase pairs alphabetically before groupby

### DIFF
--- a/kissim/comparison/matrix.py
+++ b/kissim/comparison/matrix.py
@@ -132,8 +132,13 @@ def kinase_distances(structure_distances, by="minimum", coverage_min=0.0):
     data = structure_distances
 
     # Filter by coverage
-    data = data[data["bit_coverage"] >= coverage_min].reset_index()
-    # Group by kinase names
+    data = data[data["bit_coverage"] >= coverage_min].reset_index(drop=True)
+    # Note: Kinase pair names must be sorted alphabetically to allow grouping by kinase pair names
+    kinase_pair_alphabetically_sorted = (
+        pd.Series(zip(data["kinase.1"], data["kinase.2"])).map(list).map(sorted)
+    )
+    data[["kinase.1", "kinase.2"]] = kinase_pair_alphabetically_sorted.to_list()
+    # Group by kinase pair names (which have been alphabetically sorted before!)
     structure_distances_grouped_by_kinases = data.groupby(by=["kinase.1", "kinase.2"], sort=False)
 
     # Get distance values per kinase pair based on given condition


### PR DESCRIPTION
## Description
Fix bug: Sort kinase pairs alphabetically before using `groupby(["kinase.1", "kinase.2"])` to group structure pairs by kinase pairs. If not alphabetically sorted grouped kinase pairs will contain (AAK, ABL1) _and_ (ABL1, AAK) although we only want to keep one of them.

This behavior was not a problem before because the input structure KLIFS IDs were sorted alphabetically based on the kinase they described.

## Todos
  - [x] Fix bug
  - [x] Add note in the comments
  - [x] Check CI

## Questions
None.

## Status
- [x] Ready to go