### PR TITLE
Fix bugs (FingerprintNormalized.kinase_name empty)

### DIFF
--- a/kissim/api/weights.py
+++ b/kissim/api/weights.py
@@ -45,7 +45,6 @@ def weights(feature_distances_path, feature_weights=None, fingerprint_distances_
     feature_distances_generator = FeatureDistancesGenerator.from_csv(feature_distances_path)
 
     # Calculate fingerprint distances
-    logger.info(f"Feature weights: {feature_weights}")
     fingerprint_distance_generator = FingerprintDistanceGenerator.from_feature_distances_generator(
         feature_distances_generator, feature_weights
     )

--- a/kissim/comparison/feature_distances_generator.py
+++ b/kissim/comparison/feature_distances_generator.py
@@ -62,7 +62,7 @@ class FeatureDistancesGenerator(BaseGenerator):
         """
 
         logger.info("GENERATE FEATURE DISTANCES")
-        logger.info(f"Number of input input fingerprints: {len(fingerprints_generator.data)}")
+        logger.info(f"Number of input fingerprints: {len(fingerprints_generator.data)}")
 
         start_time = datetime.datetime.now()
         logger.info(f"Feature distances generation started at: {start_time}")

--- a/kissim/encoding/fingerprint_normalized.py
+++ b/kissim/encoding/fingerprint_normalized.py
@@ -33,6 +33,7 @@ class FingerprintNormalized(FingerprintBase):
 
         fingerprint_normalized = cls()
         fingerprint_normalized.structure_klifs_id = fingerprint.structure_klifs_id
+        fingerprint_normalized.kinase_name = fingerprint.kinase_name
         fingerprint_normalized.residue_ids = fingerprint.residue_ids
         fingerprint_normalized.residue_ixs = fingerprint.residue_ixs
 

--- a/kissim/tests/encoding/test_fingerprint_normalized.py
+++ b/kissim/tests/encoding/test_fingerprint_normalized.py
@@ -32,6 +32,12 @@ class TestFingerprintNormalized:
 
         fingerprint = Fingerprint.from_structure_klifs_id(structure_klifs_id, LOCAL)
         fingerprint_normalized = FingerprintNormalized.from_fingerprint(fingerprint)
+        assert isinstance(fingerprint_normalized, FingerprintNormalized)
+        assert fingerprint.structure_klifs_id == fingerprint_normalized.structure_klifs_id
+        assert fingerprint.kinase_name == fingerprint_normalized.kinase_name
+        assert fingerprint.residue_ids == fingerprint_normalized.residue_ids
+        assert fingerprint.residue_ixs == fingerprint_normalized.residue_ixs
+        # Test the only remaining attribute `values_dict` below!
 
     @pytest.mark.parametrize(
         "values, values_normalized",


### PR DESCRIPTION
## Description
Fix bugs in `FingerprintNormalized`, caught when running `kissim` pipeline on normalized fingerprints.

## Todos
  - [x] FIX: `FingerprintNormalized`: Assign value to kinase name!!!
  - [x] ADD: `FingerprintNormalized` unit tests checking _all_ class attributes was missing > now added!
  - [x] Remove redundant logging info and redundant word in logging info

## Questions
None.

## Status
- [x] Ready to go