### PR TITLE
Set logger level + clean up unit tests output

### DIFF
--- a/kissim/cli/utils.py
+++ b/kissim/cli/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import platform
 
 
-def configure_logger(filename=None, level=logging.INFO):
+def configure_logger(filename=None, level_kissim=logging.INFO, level_opencadd=logging.WARN):
     """
     Configure logging.
 
@@ -17,8 +17,10 @@ def configure_logger(filename=None, level=logging.INFO):
     ----------
     filename : str or None
         Path to log file.
-    level : int
-        Logging level (default: INFO).
+    level_kissim : int
+        Logging level for kissim package (default: INFO).
+    level_opencadd : int
+        Logging level for opencadd package (default: WARN).
     """
 
     # Get logger for both the kissim and opencadd package
@@ -26,8 +28,8 @@ def configure_logger(filename=None, level=logging.INFO):
     logger_opencadd = logging.getLogger("opencadd")
 
     # Set logger levels
-    logger_kissim.setLevel(level)
-    logger_opencadd.setLevel(level)
+    logger_kissim.setLevel(level_kissim)
+    logger_opencadd.setLevel(level_opencadd)
 
     # Get formatter
     formatter = logging.Formatter(logging.BASIC_FORMAT)

--- a/kissim/tests/cli/test_cli_compare.py
+++ b/kissim/tests/cli/test_cli_compare.py
@@ -140,5 +140,6 @@ def test_compare_from_cli(args):
 )
 def test_compare_from_cli_error(args, error):
 
-    with pytest.raises(error):
-        compare_from_cli(args)
+    with enter_temp_directory():
+        with pytest.raises(error):
+            compare_from_cli(args)

--- a/kissim/tests/cli/test_main_compare.py
+++ b/kissim/tests/cli/test_main_compare.py
@@ -34,6 +34,17 @@ def test_main_compare(fingerprint_generator, args):
     input_filepath = Path(args[3])
     output_path = Path(args[5])
 
+    # Hardcode output files
+    feature_distances_filepath = output_path / "feature_distances.csv"
+    fingerprint_distance_filepath = output_path / "fingerprint_distances.csv"
+    fingerprint_distances_to_kinase_clusters_filepath = (
+        output_path / "fingerprint_distances_to_kinase_clusters.tree"
+    )
+    fingerprint_distances_to_kinase_matrix_filepath = (
+        output_path / "fingerprint_distances_to_kinase_matrix.csv"
+    )
+    kinase_annotation_filepath = output_path / "kinase_annotation.csv"
+
     # Generate
     fingerprint_generator.to_json(input_filepath)
 
@@ -41,7 +52,6 @@ def test_main_compare(fingerprint_generator, args):
 
     ### Feature distances generator
     # CSV file there?
-    feature_distances_filepath = output_path / "feature_distances.csv"
     assert feature_distances_filepath.exists()
     # CSV file can be loaded as FeatureDistancesGeneration object?
     feature_distances_generator = FeatureDistancesGenerator.from_csv(feature_distances_filepath)
@@ -50,7 +60,6 @@ def test_main_compare(fingerprint_generator, args):
 
     ### Fingerprint distance generator
     # CSV file there?
-    fingerprint_distance_filepath = output_path / "fingerprint_distances.csv"
     assert fingerprint_distance_filepath.exists()
     # CSV file can be loaded as FingerprintDistanceGeneration object?
     fingerprint_distance_generator = FingerprintDistanceGenerator.from_csv(
@@ -59,11 +68,24 @@ def test_main_compare(fingerprint_generator, args):
     assert isinstance(fingerprint_distance_generator, FingerprintDistanceGenerator)
     assert isinstance(fingerprint_distance_generator.data, pd.DataFrame)
 
+    ### Matrix and tree files
+    assert fingerprint_distances_to_kinase_clusters_filepath.exists()
+    assert fingerprint_distances_to_kinase_matrix_filepath.exists()
+    assert kinase_annotation_filepath.exists()
+
     # Delete file - cannot be done within enter_tmp_directory, since temporary files
     # apparently cannot be read from CLI
-    input_filepath.unlink()
-    feature_distances_filepath.unlink()
-    fingerprint_distance_filepath.unlink()
+    filepaths = [
+        input_filepath,
+        feature_distances_filepath,
+        fingerprint_distance_filepath,
+        fingerprint_distances_to_kinase_clusters_filepath,
+        fingerprint_distances_to_kinase_matrix_filepath,
+        kinase_annotation_filepath,
+    ]
+    for filepath in filepaths:
+        if filepath.exists():
+            filepath.unlink()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Set logger level + clean up unit tests output

## Todos
  - [x] Specify logger levels for `kissim` (INFO) and `opencadd` (WARN)
  - [x] Remove output files from all CLI tests

## Questions
None.

## Status
- [x] Ready to go