### PR TITLE
Fix bug in `viewer` module

### DIFF
--- a/kissim/viewer/base.py
+++ b/kissim/viewer/base.py
@@ -241,7 +241,37 @@ class _BaseViewer:
         component_counter,
     ):
         """
-        TODO
+        Show structure with
+        - residue coloring based on feature name
+        - protein with/without pocket side chains
+        - ligand
+        - pocket center
+
+        Parameters
+        ----------
+        view : nglview.widget.NGLWidget
+            NGLview widget to draw in.
+        structure_id : int
+            KLIFS structure ID.
+        text : str
+            Structure coordinates.
+        fingerprint : kissim.encoding.Fingerprint
+            Structure fingerprint.
+        ligand : str
+            Ligand expo ID.
+        feature_name : str
+            Name of feature whose values shall be mapped onto the structure.
+        show_side_chains : bool
+            Show side chains.
+        component_counter : int
+            Latest NGLview component ID before adding new stuff.
+
+        Returns
+        -------
+        view : nglview.widget.NGLWidget
+            NGLview widget with all new components and representations.
+        component_counter : int
+            Latest NGLview component ID after having added new stuff.
         """
 
         # Residue coloring based on feature name
@@ -255,7 +285,7 @@ class _BaseViewer:
         component = nglview.TextStructure(text, ext="pdb")
         view.add_component(component, name=f"{structure_id}")
 
-        # Add reference protein with/without side chains
+        # Add protein with/without pocket side chains
         if show_side_chains:
             residue_ids = fingerprint.residue_ids
             selection = " or ".join([str(i) for i in residue_ids])
@@ -294,7 +324,7 @@ class _BaseViewer:
 
         component_counter += 1
 
-        # Add subpocket center
+        # Add pocket center
         if feature_name in fingerprint.subpocket_centers.columns:
             center = fingerprint.subpocket_centers[feature_name].to_list()
             view.shape.add_sphere(center, [0.0, 0.0, 0.0], 1, f"{feature_name}")
@@ -336,12 +366,12 @@ class _BaseViewer:
             cmap_name = "viridis"
 
         # Define norm
-        # Discrete values and seqential colormap
+        # Discrete values and sequential colormap
         if discrete and not divergent:
             discrete_options = self._discrete_feature_values[feature_name]
             norm = colors.Normalize(vmin=min(discrete_options), vmax=max(discrete_options))
             cmap = cm.get_cmap(cmap_name, len(discrete_options))
-        # Continuous values and seqential colormap
+        # Continuous values and sequential colormap
         elif not discrete and not divergent:
             norm = colors.Normalize(vmin=data.min(), vmax=data.max())
             cmap = cm.get_cmap(cmap_name)

--- a/kissim/viewer/kinase.py
+++ b/kissim/viewer/kinase.py
@@ -102,6 +102,9 @@ class KinaseViewer(_BaseViewer):
 
         data = self._std[feature_name]
         data.index = fingerprint.residue_ids
+        # If residue IDs contain None values, `data.index` will be of type float; we need int
+        data.index = data.index.astype("Int32")
+        
         residue_to_color = self._residue_to_color_mapping(
             feature_name,
             data,

--- a/kissim/viewer/kinase.py
+++ b/kissim/viewer/kinase.py
@@ -104,7 +104,7 @@ class KinaseViewer(_BaseViewer):
         data.index = fingerprint.residue_ids
         # If residue IDs contain None values, `data.index` will be of type float; we need int
         data.index = data.index.astype("Int32")
-        
+
         residue_to_color = self._residue_to_color_mapping(
             feature_name,
             data,

--- a/kissim/viewer/pair.py
+++ b/kissim/viewer/pair.py
@@ -66,6 +66,9 @@ class StructurePairViewer(_BaseViewer):
 
         data = self._diff[feature_name]
         data.index = fingerprint.residue_ids
+        # If residue IDs contain None values, `data.index` will be of type float; we need int
+        data.index = data.index.astype("Int32")
+
         residue_to_color = self._residue_to_color_mapping(
             feature_name,
             data,

--- a/kissim/viewer/structure.py
+++ b/kissim/viewer/structure.py
@@ -50,6 +50,9 @@ class StructureViewer(_BaseViewer):
         if feature_name in self._fingerprint.physicochemical:
             data = fingerprint.physicochemical[feature_name]
             data.index = fingerprint.residue_ids
+            # If residue IDs contain None values, `data.index` will be of type float; we need int
+            data.index = data.index.astype("Int32")
+
             residue_to_color = self._residue_to_color_mapping(
                 feature_name,
                 data,
@@ -60,6 +63,9 @@ class StructureViewer(_BaseViewer):
         elif feature_name in self._fingerprint.distances:
             data = fingerprint.distances[feature_name]
             data.index = fingerprint.residue_ids
+            # If residue IDs contain None values, `data.index` will be of type float; we need int
+            data.index = data.index.astype("Int32")
+            
             residue_to_color = self._residue_to_color_mapping(
                 feature_name,
                 data,

--- a/kissim/viewer/structure.py
+++ b/kissim/viewer/structure.py
@@ -65,7 +65,7 @@ class StructureViewer(_BaseViewer):
             data.index = fingerprint.residue_ids
             # If residue IDs contain None values, `data.index` will be of type float; we need int
             data.index = data.index.astype("Int32")
-            
+
             residue_to_color = self._residue_to_color_mapping(
                 feature_name,
                 data,


### PR DESCRIPTION
## Description
Fix bug in `viewer` module

Problem: If structures are missing KLIFS pocket residues, `fingerprint.residue_ids` will contain None values. We use these residues as DataFrame index, which casts the IDs to floats; using floats to color residues with `nglview` does not work and therefore the respective structures cannot be colored.

Solution: Cast DataFrame index to `Int32`; None and integers can live side-by-side.

## Todos
  - [x] Fix bug as described above

## Questions
None

## Status
- [x] Ready to go