### PR TITLE
Fix `kissim.viewer` discrete colorbar

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - biopython=1.77
   - numpy
   - scipy
-  - matplotlib-base<3.5
+  - matplotlib-base
   - seaborn
   - jupyter
   - jupyterlab>=3

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - biopython=1.77
   - numpy
   - scipy
-  - matplotlib-base
+  - matplotlib-base<3.5
   - seaborn
   - jupyter
   - jupyterlab>=3

--- a/kissim/viewer/base.py
+++ b/kissim/viewer/base.py
@@ -458,5 +458,5 @@ class _BaseViewer:
         )
         # If categorial, exchange tick labels with meaningful text
         if isinstance(norm, colors.NoNorm):
-            cbar.ax.set_xticks(range(0, len(cmap.colors)))
-            cbar.ax.set_xticklabels(xticklabels)
+            cbar.set_ticks(range(0, len(cmap.colors)))
+            cbar.set_ticklabels(xticklabels)

--- a/kissim/viewer/base.py
+++ b/kissim/viewer/base.py
@@ -15,7 +15,6 @@ from opencadd.databases.klifs import setup_remote
 
 from kissim.definitions import FEATURE_METADATA, DISCRETE_FEATURE_VALUES
 from kissim.encoding.fingerprint_generator import FingerprintGenerator
-from kissim.viewer import KinaseViewer
 
 
 class _BaseViewer:
@@ -183,6 +182,8 @@ class _BaseViewer:
 
         # If case of the KinaseViewer, do not show the first 6 SiteAlign features,
         # since they are identical between structures of the same kinase.
+        # KinaseViewer import must be here, otherwise circular import problem
+        from kissim.viewer import KinaseViewer
         if isinstance(self, KinaseViewer):
             options = options[6:]
         value = options[0]

--- a/kissim/viewer/base.py
+++ b/kissim/viewer/base.py
@@ -184,10 +184,10 @@ class _BaseViewer:
         # since they are identical between structures of the same kinase.
         # KinaseViewer import must be here, otherwise circular import problem
         from kissim.viewer import KinaseViewer
+
         if isinstance(self, KinaseViewer):
             options = options[6:]
         value = options[0]
-            
 
         interact(
             self._show,

--- a/kissim/viewer/base.py
+++ b/kissim/viewer/base.py
@@ -15,6 +15,7 @@ from opencadd.databases.klifs import setup_remote
 
 from kissim.definitions import FEATURE_METADATA, DISCRETE_FEATURE_VALUES
 from kissim.encoding.fingerprint_generator import FingerprintGenerator
+from kissim.viewer import KinaseViewer
 
 
 class _BaseViewer:
@@ -178,11 +179,20 @@ class _BaseViewer:
         Show features mapped onto the 3D pocket (select feature interactively).
         """
 
+        options = self._feature_names
+
+        # If case of the KinaseViewer, do not show the first 6 SiteAlign features,
+        # since they are identical between structures of the same kinase.
+        if isinstance(self, KinaseViewer):
+            options = options[6:]
+        value = options[0]
+            
+
         interact(
             self._show,
             feature_name=widgets.Dropdown(
-                options=self._feature_names,
-                value="size",
+                options=options,
+                value=value,
                 description="Feature: ",
                 disabled=False,
             ),
@@ -458,5 +468,5 @@ class _BaseViewer:
         )
         # If categorial, exchange tick labels with meaningful text
         if isinstance(norm, colors.NoNorm):
-            cbar.set_ticks(range(0, len(cmap.colors)))
+            cbar.set_ticks(range(0, len(xticklabels)))
             cbar.set_ticklabels(xticklabels)

--- a/kissim/viewer/base.py
+++ b/kissim/viewer/base.py
@@ -450,7 +450,7 @@ class _BaseViewer:
 
         fig, ax = plt.subplots(figsize=(6, 1))
         fig.subplots_adjust(bottom=0.5)
-        fig.colorbar(
+        cbar = fig.colorbar(
             cm.ScalarMappable(norm=norm, cmap=cmap),
             cax=ax,
             orientation="horizontal",
@@ -458,4 +458,5 @@ class _BaseViewer:
         )
         # If categorial, exchange tick labels with meaningful text
         if isinstance(norm, colors.NoNorm):
-            ax.set_xticklabels(xticklabels)
+            cbar.ax.set_xticks(range(0, len(cmap.colors)))
+            cbar.ax.set_xticklabels(xticklabels)


### PR DESCRIPTION
## Description
In `kissim.viewer`, the colorbar for discrete features is incorrect.
See https://github.com/volkamerlab/kissim/issues/99.

EDIT: For the time being, I pinned `matplotlib` to version 3.4.3 on the `master` branch.

## Todos
  - [x] [Minor] Viewer: Fix UserWarning (FixedFormatter only with FixedLocator)
  - [x] [Minor] Viewer: Fix UserWarning: Use the colorbar set_ticks() method instead.
  - [x] Fix colorbar for discrete values: https://github.com/matplotlib/matplotlib/issues/21870; for the time being pin `matplotlib` version to <3.5

## Questions
None

## Status
- [x] Ready to go