### PR TITLE
Pin matplotlib to <3.5

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - biopython=1.77
   - numpy
   - scipy
-  - matplotlib-base
+  - matplotlib-base<3.5
   - seaborn
   - jupyter
   - jupyterlab>=3


### PR DESCRIPTION
## Description
Pin `matplotlib` to <3.5 to ensure correct colorbar for discrete KiSSim features in `kissim.viewer`.

## Todos
  - [x] Pin `matplotlib` to <3.5 in test env

## Questions
None.

## Status
- [x] Ready to go